### PR TITLE
REPO_COMMIT 옵션을 사용시 git pull 에러 처리 문제

### DIFF
--- a/easy-stable-diffusion.py
+++ b/easy-stable-diffusion.py
@@ -735,7 +735,7 @@ def setup_webui() -> None:
             # 사용자 파일만 남겨두고 레포지토리 초기화하기
             # https://stackoverflow.com/a/12096327
             execute(
-                'git stash && git pull',
+                'git stash && git pull origin master',
                 cwd=repo_dir
             )
         except subprocess.CalledProcessError:


### PR DESCRIPTION
REPO_COMMIT 옵션을 사용해 체크아웃한 경우 git pull 요청시 브랜치를 지정하지 않으면 'You are not currently on a branch.' 에러를 발생해 기존 체크아웃한 레포지토리 디렉터리를 삭제하고 다시 clone하는 문제 수정